### PR TITLE
chore: upgrade lottie-web

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "string-replace-loader": "^2.2.0",
     "webpack": "^4.39.1",
     "webpack-cli": "^3.3.6",
-    "lottie-web": "^5.7.4",
+    "lottie-web": "^5.12.2",
     "copy-webpack-plugin": "^6.0.3"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,12 +15,11 @@ module.exports = {
     rules: [{
       test: /\.js$/i,
       use: [{
-        loader: 'eslint-loader',
-      }, {
         loader: 'babel-loader',
         options: {
           presets: ['@babel/preset-env'],
           plugins: ['@babel/plugin-proposal-class-properties'],
+          sourceType: 'unambiguous',
         },
       }, {
         loader: 'string-replace-loader',
@@ -32,8 +31,8 @@ module.exports = {
             search: '__[STANDALONE]__',
             replace: '',
           }]
-        }
-      }],
+        },
+      }, 'eslint-loader'],
       exclude: /node_modules/
     }]
   },


### PR DESCRIPTION
1、升级 lottie-web
2、babel-config，添加 sourceType: 'unambiguous'
3、eslint-loader 挪到最后（loader执行顺序是 right to left，怕是写反了，检测的是dist里的js）